### PR TITLE
Updates for Jekyll 3.x.

### DIFF
--- a/pandoc_markdown.rb
+++ b/pandoc_markdown.rb
@@ -1,74 +1,16 @@
 module Jekyll
   module Converters
-    class Markdown < Converter
-      safe true
-
-      pygments_prefix "\n"
-      pygments_suffix "\n"
-
-      def setup
-        return if @setup
-        @parser = case @config['markdown']
-          when 'redcarpet'
-            RedcarpetParser.new @config
-          when 'kramdown'
-            KramdownParser.new @config
-          when 'rdiscount'
-            RDiscountParser.new @config
-          when 'maruku'
-            MarukuParser.new @config
-          when 'pandoc'
-            PandocParser.new @config
-          else
-            STDERR.puts "Invalid Markdown processor: #{@config['markdown']}"
-            STDERR.puts " Valid options are [ maruku | rdiscount | kramdown ]"
-            raise FatalException.new("Invalid Markdown process: #{@config['markdown']}")
-        end
-        @setup = true
-      end
-
-      def matches(ext)
-        rgx = '(' + @config['markdown_ext'].gsub(',','|') +')'
-        ext =~ Regexp.new(rgx, Regexp::IGNORECASE)
-      end
-
-      def output_ext(ext)
-        ".html"
-      end
-
-      def convert(content)
-        setup
-        @parser.convert(content)
-      end
-    end
-  end
-end
-
-module Jekyll
-  module Converters
     class Markdown
-      class PandocParser
+      class Pandoc
         def initialize(config)
-          require 'pandoc-ruby'
-          @config = config
-        rescue LoadError
-          STDERR.puts 'You are missing a library required for Pandoc. Please run:'
-          STDERR.puts ' $ [sudo] gem install pandoc-ruby'
-          raise FatalException.new("Missing dependency: pandoc-ruby")
+          Jekyll::External.require_with_graceful_fail "pandoc-ruby"
+          @config = config["pandoc"] || {}
         end
 
         def convert(content)
-          extensions = config_option('extensions', [])
-          format = config_option('format', 'html5')
-
-          PandocRuby.new(content, *extensions).send("to_#{format}")
-        end
-
-        def config_option(key, default=nil)
-          case @config['pandoc']
-            when nil then default
-            else @config['pandoc'].fetch(key, default)
-          end
+          extensions = @config['extensions'] || []
+          format = @config['format'] || 'html5'
+          ::PandocRuby.new(content, *extensions).send("to_#{format}")
         end
       end
     end


### PR DESCRIPTION
I'm creating a pull request even though the project is dead just in case any one else wants to use this plugin for Jekyll 3.x.

This is similar to #12, but further simplifies the plugin based on the examples in Jekyll 3.x default markdown processors, e.g. https://github.com/jekyll/jekyll/blob/master/lib/jekyll/converters/markdown/rdiscount_parser.rb

There is one small snag with this version: You need to enable it with `markdown: Pandoc` instead of `markdown: pandoc` because Jekyll's logic for detecting third-party processors does not perform a downcase any more (as best I can tell).

This version will live for the forseable future in my fork of the project (unless the author decides to revive things): https://github.com/elliottslaughter/jekyll-pandoc-plugin